### PR TITLE
Parameterize number of tracked access streams in Multi Next Line Prefetcher

### DIFF
--- a/src/main/scala/NextLine.scala
+++ b/src/main/scala/NextLine.scala
@@ -99,11 +99,14 @@ class SingleNextLinePrefetcher(params: SingleNextLinePrefetcherParams)(implicit 
 
 
 case class MultiNextLinePrefetcherParams(
-  singles: Seq[SingleNextLinePrefetcherParams] = Seq.fill(4) { SingleNextLinePrefetcherParams() },
-  handleVA: Boolean = false
-) extends CanInstantiatePrefetcher {
+  handleVA: Boolean = false,
+  streams: Int = 4
+)extends CanInstantiatePrefetcher {
   def desc() = "Multi Next-Line Prefetcher"
-  def instantiate()(implicit p: Parameters) = Module(new MultiNextLinePrefetcher(this)(p))
+  val singles: Seq[SingleNextLinePrefetcherParams] =
+    Seq.fill(streams)(SingleNextLinePrefetcherParams())
+  def instantiate()(implicit p: Parameters) =
+    Module(new MultiNextLinePrefetcher(this)(p))
 }
 
 class MultiNextLinePrefetcher(params: MultiNextLinePrefetcherParams)(implicit p: Parameters) extends AbstractPrefetcher()(p) {


### PR DESCRIPTION
Hello,

This is a simple change that parameterizes the number of  SingleNextLinePrefetchers instantiated inside a MultiNextLinePrefetcher.

This allows a user to specify the number inside of a configuration fragment when instantiating a top level TargetConfig. 

For example:

 new barf.WithTLDCachePrefetcher(new barf.MultiNextLinePrefetcherParams(streams=8, handleVA = true)) ++
